### PR TITLE
Feature/async android

### DIFF
--- a/RNImageToPdf.podspec
+++ b/RNImageToPdf.podspec
@@ -11,11 +11,10 @@ Pod::Spec.new do |s|
   s.license      = "MIT"
   s.author       = { package["author"]["name"] => package["author"]["email"] }
   s.platform     = :ios, "7.0"
-  s.source       = { :git => "https://github.com/author/RNImageToPdf.git", :tag => "master" }
-  s.source_files  = "RNImageToPdf/**/*.{h,m}"
+  s.source       = { :git => "https://github.com/frenberg/RNImageToPdf.git", :branch => "master" }
+  s.source_files  = "ios/**/*.{h,m}"
   s.requires_arc = true
 
   s.dependency "React"
-  #s.dependency "others"
 
 end

--- a/android/src/main/java/com/anyline/RNImageToPDF/BitmapUtils.java
+++ b/android/src/main/java/com/anyline/RNImageToPDF/BitmapUtils.java
@@ -1,0 +1,54 @@
+package com.anyline.RNImageToPDF;
+
+import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
+import android.net.Uri;
+import android.os.ParcelFileDescriptor;
+
+import com.facebook.react.bridge.ReactApplicationContext;
+
+import java.io.ByteArrayOutputStream;
+import java.io.FileDescriptor;
+import java.io.IOException;
+
+class BitmapUtils {
+    static Bitmap getImageFromFile(String path, ReactApplicationContext reactContext) throws IOException {
+        if (path.startsWith("content://")) {
+            return getImageFromContentResolver(path, reactContext);
+        }
+
+        BitmapFactory.Options options = new BitmapFactory.Options();
+        options.inPreferredConfig = Bitmap.Config.ARGB_8888;
+        return BitmapFactory.decodeFile(path, options);
+    }
+
+    private static Bitmap getImageFromContentResolver(String path, ReactApplicationContext reactContext) throws IOException {
+        ParcelFileDescriptor parcelFileDescriptor = reactContext.getContentResolver().openFileDescriptor(Uri.parse(path), "r");
+        FileDescriptor fileDescriptor = parcelFileDescriptor.getFileDescriptor();
+        Bitmap image = BitmapFactory.decodeFileDescriptor(fileDescriptor);
+        parcelFileDescriptor.close();
+        return image;
+    }
+
+    static Bitmap resize(Bitmap bitmap, int maxWidth, int maxHeight) {
+        if (maxWidth == 0 || maxHeight == 0) return bitmap;
+        if (bitmap.getWidth() <= maxWidth && bitmap.getHeight() <= maxHeight) return bitmap;
+
+        double aspectRatio = (double) bitmap.getHeight() / bitmap.getWidth();
+        int height = Math.round(maxWidth * aspectRatio) < maxHeight ? (int) Math.round(maxWidth * aspectRatio) : maxHeight;
+        int width = (int) Math.round(height / aspectRatio);
+
+        return Bitmap.createScaledBitmap(bitmap, width, height, true);
+    }
+
+    static Bitmap compress(Bitmap bmp, int quality) throws IOException {
+        if (quality <= 0 || quality >= 100) return bmp;
+
+        ByteArrayOutputStream stream = new ByteArrayOutputStream();
+        bmp.compress(Bitmap.CompressFormat.JPEG, quality, stream);
+        byte[] byteArray = stream.toByteArray();
+        stream.close();
+        return BitmapFactory.decodeByteArray(byteArray, 0, byteArray.length);
+    }
+
+}

--- a/android/src/main/java/com/anyline/RNImageToPDF/CreatePDFAsyncTask.java
+++ b/android/src/main/java/com/anyline/RNImageToPDF/CreatePDFAsyncTask.java
@@ -1,0 +1,106 @@
+package com.anyline.RNImageToPDF;
+
+import android.graphics.Bitmap;
+import android.graphics.Canvas;
+import android.graphics.pdf.PdfDocument;
+import android.os.AsyncTask;
+
+import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.Promise;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.ReadableArray;
+import com.facebook.react.bridge.ReadableMap;
+import com.facebook.react.bridge.WritableMap;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+
+import static java.lang.String.format;
+
+public class CreatePDFAsyncTask extends AsyncTask<Void, Void, WritableMap> {
+
+
+    private final ReactApplicationContext mContext;
+    private final Promise mPromise;
+    private final ReadableMap mOptions;
+
+    public CreatePDFAsyncTask(ReactApplicationContext context, Promise promise, ReadableMap options) {
+        mContext = context;
+        mPromise = promise;
+        mOptions = options;
+    }
+
+    @Override
+    protected WritableMap doInBackground(Void... ignored) {
+        if (isCancelled()) return null;
+
+        ReadableArray images = mOptions.getArray("imagePaths");
+
+        String documentName = mOptions.getString("name");
+
+        ReadableMap maxSize = mOptions.hasKey("maxSize") ? mOptions.getMap("maxSize") : null;
+        int maxHeight = maxSize != null && maxSize.hasKey("height") ? maxSize.getInt("height") : 0;
+        int maxWidth = maxSize != null && maxSize.hasKey("width") ? maxSize.getInt("width") : 0;
+
+        int quality = mOptions.hasKey("quality") ? (int) Math.round(100 * mOptions.getDouble("quality")) : 0;
+
+        PdfDocument document = new PdfDocument();
+
+        WritableMap result = Arguments.createMap();
+
+        try {
+            for (int idx = 0; idx < images.size(); idx++) {
+
+                // get image
+                Bitmap bmp = BitmapUtils.getImageFromFile(images.getString(idx), mContext);
+
+                // resize
+                bmp = BitmapUtils.resize(bmp, maxWidth, maxHeight);
+
+                // compress
+                bmp = BitmapUtils.compress(bmp, quality);
+
+                PdfDocument.PageInfo pageInfo = new PdfDocument.PageInfo.Builder(bmp.getWidth(), bmp.getHeight(), 1).create();
+
+                // start a page
+                PdfDocument.Page page = document.startPage(pageInfo);
+
+                // add image to page
+                Canvas canvas = page.getCanvas();
+                canvas.drawBitmap(bmp, 0, 0, null);
+
+                document.finishPage(page);
+
+                if (isCancelled()) {
+                    document.close();
+                    return null;
+                }
+            }
+
+            // write the document content
+            File targetPath = mContext.getExternalFilesDir(null);
+            File filePath = new File(targetPath, documentName);
+            document.writeTo(new FileOutputStream(filePath));
+
+            result.putString("filePath", filePath.getAbsolutePath());
+        } catch (IOException e) {
+            document.close();
+            return null;
+        }
+
+        document.close();
+
+        return result;
+    }
+
+    @Override
+    protected void onPostExecute(WritableMap result) {
+        super.onPostExecute(result);
+
+        if (result == null) {
+            mPromise.reject("no.result", "No result");
+        }
+        mPromise.resolve(result);
+    }
+}

--- a/android/src/main/java/com/anyline/RNImageToPDF/RNImageToPdf.java
+++ b/android/src/main/java/com/anyline/RNImageToPDF/RNImageToPdf.java
@@ -36,13 +36,10 @@ import static java.lang.String.format;
 public class RNImageToPdf extends ReactContextBaseJavaModule {
 
     public static final String REACT_CLASS = "RNImageToPdf";
-
-    private final ReactApplicationContext reactContext;
     private static final Logger log = Logger.getLogger(RNImageToPdf.REACT_CLASS);
 
     RNImageToPdf(ReactApplicationContext context) {
         super(context);
-        this.reactContext = context;
     }
 
     @Override
@@ -52,94 +49,7 @@ public class RNImageToPdf extends ReactContextBaseJavaModule {
 
     @ReactMethod
     public void createPDFbyImages(ReadableMap options, final Promise promise) {
-        ReadableArray images = options.getArray("imagePaths");
+        new CreatePDFAsyncTask(getReactApplicationContext(), promise, options).execute();
 
-        String documentName = options.getString("name");
-
-        ReadableMap maxSize = options.hasKey("maxSize") ? options.getMap("maxSize") : null;
-        int maxHeight = maxSize != null && maxSize.hasKey("height") ? maxSize.getInt("height") : 0;
-        int maxWidth = maxSize != null && maxSize.hasKey("width") ? maxSize.getInt("width") : 0;
-
-        int quality = options.hasKey("quality") ? (int)Math.round(100 * options.getDouble("quality")) : 0;
-
-        PdfDocument document = new PdfDocument();
-        try {
-
-            for (int idx = 0; idx < images.size(); idx++) {
-                // get image
-                Bitmap bmp = getImageFromFile(images.getString(idx));
-
-                // resize
-                bmp = resize(bmp, maxWidth, maxHeight);
-
-                // compress
-                bmp = compress(bmp, quality);
-
-                PageInfo pageInfo = new Builder(bmp.getWidth(), bmp.getHeight(), 1).create();
-
-                // start a page
-                Page page = document.startPage(pageInfo);
-
-                // add image to page
-                Canvas canvas = page.getCanvas();
-                canvas.drawBitmap(bmp, 0, 0, null);
-
-                document.finishPage(page);
-            }
-
-            // write the document content
-            File targetPath = reactContext.getExternalFilesDir(null);
-            File filePath = new File(targetPath, documentName);
-            document.writeTo(new FileOutputStream(filePath));
-            log.info(format("Wrote %,d bytes to %s", filePath.length(), filePath.getPath()));
-            WritableMap resultMap = Arguments.createMap();
-            resultMap.putString("filePath", filePath.getAbsolutePath());
-            promise.resolve(resultMap);
-        } catch (Exception e) {
-            promise.reject("failed", e);
-        }
-
-        // close the document
-        document.close();
     }
-
-    private Bitmap getImageFromFile(String path) throws IOException {
-        if (path.startsWith("content://")) {
-            return getImageFromContentResolver(path);
-        }
-
-        BitmapFactory.Options options = new BitmapFactory.Options();
-        options.inPreferredConfig = Bitmap.Config.ARGB_8888;
-        return BitmapFactory.decodeFile(path, options);
-    }
-
-    private Bitmap getImageFromContentResolver(String path) throws IOException {
-        ParcelFileDescriptor parcelFileDescriptor = reactContext.getContentResolver().openFileDescriptor(Uri.parse(path), "r");
-        FileDescriptor fileDescriptor = parcelFileDescriptor.getFileDescriptor();
-        Bitmap image = BitmapFactory.decodeFileDescriptor(fileDescriptor);
-        parcelFileDescriptor.close();
-        return image;
-    }
-
-    private Bitmap resize(Bitmap bitmap, int maxWidth, int maxHeight) {
-        if (maxWidth == 0 || maxHeight == 0) return bitmap;
-        if (bitmap.getWidth() <= maxWidth && bitmap.getHeight() <= maxHeight) return bitmap;
-
-        double aspectRatio = (double) bitmap.getHeight() / bitmap.getWidth();
-        int height = Math.round(maxWidth * aspectRatio) < maxHeight ? (int) Math.round(maxWidth * aspectRatio) : maxHeight;
-        int width = (int) Math.round(height / aspectRatio);
-
-        return Bitmap.createScaledBitmap(bitmap, width, height, true);
-    }
-
-    private Bitmap compress(Bitmap bmp, int quality) throws IOException {
-        if (quality <= 0 || quality >= 100) return bmp;
-
-        ByteArrayOutputStream stream = new ByteArrayOutputStream();
-        bmp.compress(Bitmap.CompressFormat.JPEG, quality, stream);
-        byte[] byteArray = stream.toByteArray();
-        stream.close();
-        return BitmapFactory.decodeByteArray(byteArray, 0, byteArray.length);
-    }
-
 }


### PR DESCRIPTION
Moving the pdf creation to worker thread

Since creating the pdf on main thread would lock the UI and require a spinner of some kind I have moved that process to a different thread so this can be done async. Not an issue on ios, so this is android only.

Also updated podspec