### PR TITLE
fix(android) NPE crash on bitmap, catch and reject

### DIFF
--- a/android/src/main/java/com/anyline/RNImageToPDF/CreatePDFAsyncTask.java
+++ b/android/src/main/java/com/anyline/RNImageToPDF/CreatePDFAsyncTask.java
@@ -14,7 +14,6 @@ import com.facebook.react.bridge.WritableMap;
 
 import java.io.File;
 import java.io.FileOutputStream;
-import java.io.IOException;
 
 import static java.lang.String.format;
 
@@ -84,7 +83,7 @@ public class CreatePDFAsyncTask extends AsyncTask<Void, Void, WritableMap> {
             document.writeTo(new FileOutputStream(filePath));
 
             result.putString("filePath", filePath.getAbsolutePath());
-        } catch (IOException e) {
+        } catch (Exception e) {
             document.close();
             return null;
         }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-image-to-pdf",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Converts images to a PDF file",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
an invalid file make bitmap null and no ioexception so an npe would cause crash